### PR TITLE
Upgrade package to Node 18+ to eliminate potential risks with deprecated features in latest glob package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "glob": "^10.2.2"
+        "glob": "^10.3.10"
       },
       "devDependencies": {
         "@types/glob": "^8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "reload": "^3.2.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "type": "module",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "format": "prettier --write '**/*'",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/markcellus/html-express-js#readme",
   "dependencies": {
-    "glob": "^10.2.2"
+    "glob": "^10.3.10"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",


### PR DESCRIPTION
Upgrades package to use the latest LTS of Node to eliminate risk of bugs caused by deprecated features in latest versions of `glob` package. Also upgrades `glob` package to latest version 10.3.10, since we're accommodating it anyway.  

To reproduce this risk, just do the following:

1. Make sure you're on Node 16 
2. Remove and uninstall all node_modules
3. Run `npm i glob` to reinstall glob dep
4. See all the deprecation warnings due to not being on Node 18

You should see something similar to this:

```console
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@octokit/request@8.1.6',
npm WARN EBADENGINE   required: { node: '>= 18' },
npm WARN EBADENGINE   current: { node: 'v16.17.1', npm: '8.15.0' }
```