### PR TITLE
Update `renderView` to return the rendered HTML

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,12 +79,13 @@ async function renderFileTemplate(path, data, state) {
  * @param {import('express').Request} req
  * @param {import('express').Response} res
  * @param {Record<string, any>} [data]
- * @returns {Promise<void>} HTML with includes available (appended to state)
+ * @returns {Promise<string>} HTML with includes available (appended to state)
  */
 export async function renderView(filePath, req, res, data = {}) {
   const requestState = buildRequestState ? await buildRequestState(req) : {};
   const html = await buildViewHtml(filePath, data, requestState);
   res.send(html);
+  return html;
 }
 
 /**


### PR DESCRIPTION
Updated so that `renderView` returns the HTML body that was rendered. This gives implementers the option of using the body for other purposes like internal caching, which is why I need it.